### PR TITLE
Add embedded `header_checks` to `HTTPObserver` with data migration fn

### DIFF
--- a/lib/httpizza/checks/header_check.ex
+++ b/lib/httpizza/checks/header_check.ex
@@ -1,0 +1,21 @@
+defmodule HTTPizza.Checks.HeaderCheck do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  embedded_schema do
+    field :value, :string
+    field :header, :string
+    field :case_sensitive, :boolean, default: true
+
+    field :comparator, Ecto.Enum,
+      values: [:contains, :equal_to, :starts_with, :ends_with, :does_not_contain, :not_equal_to]
+  end
+
+  @doc false
+  def changeset(header_check, attrs) do
+    header_check
+    |> cast(attrs, [:value, :header, :comparator, :case_sensitive])
+    |> validate_required([:value, :header, :comparator, :case_sensitive])
+  end
+end

--- a/lib/httpizza/observers/http_observer.ex
+++ b/lib/httpizza/observers/http_observer.ex
@@ -1,4 +1,6 @@
 defmodule HTTPizza.Observers.HTTPObserver do
+  require Logger
+
   use Ecto.Schema
 
   import Ecto.Changeset
@@ -21,6 +23,7 @@ defmodule HTTPizza.Observers.HTTPObserver do
     has_many :http_observations, HTTPizza.Observers.HTTPObservation
 
     embeds_many :email_recipients, HTTPizza.Notifications.EmailRecipient
+    embeds_many :header_checks, HTTPizza.Checks.HeaderCheck, on_replace: :delete
 
     timestamps()
   end
@@ -33,6 +36,12 @@ defmodule HTTPizza.Observers.HTTPObserver do
     http_observer
     |> changeset(Map.delete(attrs, :organization))
     |> put_assoc(:organization, organization)
+  end
+
+  def changeset(http_observer, %{header_checks: header_checks} = attrs) do
+    http_observer
+    |> changeset(Map.delete(attrs, :header_checks))
+    |> put_embed(:header_checks, header_checks)
   end
 
   @doc false
@@ -64,5 +73,46 @@ defmodule HTTPizza.Observers.HTTPObserver do
       # every day
       "0 0 * * *"
     ])
+  end
+
+  @doc """
+  Migrate associated `http_head_checks` into embedded `header_checks`
+  """
+  def migrate_header_check() do
+    observers =
+      HTTPizza.Observers.list_http_observers() |> HTTPizza.Repo.preload(:http_head_checks)
+
+    results =
+      Enum.map(observers, fn %{id: id} = observer ->
+        with {:ok, _} <-
+               HTTPizza.Observers.update_http_observer(observer, %{
+                 path:
+                   if(not is_nil(observer.path) and observer.path != "",
+                     do: observer.path,
+                     else: "/"
+                   ),
+                 header_checks:
+                   Enum.map(observer.http_head_checks, fn http_head_check ->
+                     Map.take(http_head_check, [:header, :value, :comparator, :case_sensitive])
+                   end)
+               }) do
+          Logger.debug(
+            "migrated `http_head_checks` => `header_checks` for `HTTPObserver` with id='#{id}'"
+          )
+
+          :ok
+        else
+          _ ->
+            Logger.error("unable to migrate `HTTPObserver` with id='#{id}'")
+            :error
+        end
+      end)
+
+    ok = Enum.filter(results, fn r -> r == :ok end) |> Enum.count()
+    failed = Enum.filter(results, fn r -> r == :error end) |> Enum.count()
+
+    Logger.info(
+      "finished migrating `http_head_checks` => `header_checks`: #{ok} ok, #{failed} failed"
+    )
   end
 end

--- a/priv/repo/migrations/20231008233118_add_header_checks_to_http_observers.exs
+++ b/priv/repo/migrations/20231008233118_add_header_checks_to_http_observers.exs
@@ -1,0 +1,9 @@
+defmodule HTTPizza.Repo.Migrations.AddHeaderChecksToHTTPObservers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:http_observers) do
+      add(:header_checks, {:array, :map})
+    end
+  end
+end


### PR DESCRIPTION
Closes #74 
Closes #75 (once migration run)